### PR TITLE
修复版面列表不返回20条时页面崩溃的问题

### DIFF
--- a/CC98.Forum/CC98.Forum/Utility.tsx
+++ b/CC98.Forum/CC98.Forum/Utility.tsx
@@ -1,4 +1,4 @@
-﻿import * as Prop from './Props/AppProps'
+import * as Prop from './Props/AppProps'
 import * as State from './States/AppState'
 import store from './Store';
 import * as UserCenterActions from './Actions/UserCenter';
@@ -83,7 +83,7 @@ export async function getBoardTopicAsync(curPage, boardId, totalTopicCount) {
                 return 'not found';
         }
         const data: State.TopicTitleAndContentState[] = await response.json();
-        for (let i = 0; i < topicNumberInPage; i++) {
+        for (let i = 0; i < data.length; i++) {
             boardtopics[i] = {
                 ...data[i], replyCount: data[i].replyCount || 0
             }


### PR DESCRIPTION
/Board/${boardId}/topic?from=${startPage}&size=${topicNumberInPage}

这个API不一定会返回要求的topicNumberInPage=20条，导致`TypeError: Cannot read property 'replyCount' of undefind`

修改代码的循环部分，改为返回数组的length