### PR TITLE
fix: style flipping on changing theme

### DIFF
--- a/CC98.Forum/CC98.Forum/Utility.tsx
+++ b/CC98.Forum/CC98.Forum/Utility.tsx
@@ -3050,11 +3050,7 @@ declare let themeNames: string[];
  * 切换主题
  */
 export function changeTheme(theme: number) {
-  $("#mainStylesheet").remove();
-  document.getElementsByTagName("head")[0].innerHTML +=
-    '<link id="mainStylesheet" type="text/css" rel="stylesheet" href="/static/content/' +
-    themeNames[theme] +
-    '">';
+  $("#mainStylesheet").attr('href', `/static/content/${themeNames[theme]}`);
 }
 export async function queryWealth(boardId) {
   const headers = await formAuthorizeHeader();


### PR DESCRIPTION
浏览器解析修改后的`document.getElementsByTagName("head")[0].innerHTML`需要时间，解析完之后按顺序加载其中的资源文件，执行此过程的数秒间，`mainStylesheet `已被L#3053`$("#mainStylesheet").remove();`移除，导致页面缺少样式文件。
此PR修复了以上问题。