### PR TITLE
fix: 个人中心侧边栏导航菜单未对齐

### DIFF
--- a/CC98.Forum/CC98.Forum/Components/UserCenter/Navigation.tsx
+++ b/CC98.Forum/CC98.Forum/Components/UserCenter/Navigation.tsx
@@ -51,14 +51,16 @@ export default class extends React.Component<props, UserCenterNavigationState> {
       <div className="user-center-navigation" id="userCenterNavigation">
         <ul>
           <li>
-            <NavLink to="/usercenter" exact activeClassName="user-center-navigation-active" className="fa-home">
+            <NavLink to="/usercenter" exact activeClassName="user-center-navigation-active" >
+              <div className="fa-home fa-fw"/>
               <div className="center-nav-item">个人主页</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/config" activeClassName="user-center-navigation-active" className="fa-cog">
-              <div className="center-nav-item">修改资料</div>
+            <NavLink to="/usercenter/config" activeClassName="user-center-navigation-active" >
+                <div className="fa-cog fa-fw"/>
+                <div className="center-nav-item">修改资料</div>
             </NavLink>
           </li>
           <hr />
@@ -66,38 +68,44 @@ export default class extends React.Component<props, UserCenterNavigationState> {
             <NavLink
               to="/usercenter/mytopics"
               activeClassName="user-center-navigation-active"
-              className="fa-pencil-square-o"
+              
             >
+              <div className="fa-pencil-square-o fa-fw" />
               <div className="center-nav-item">我的主题</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/myposts" activeClassName="user-center-navigation-active" className="fa-mail-reply">
+            <NavLink to="/usercenter/myposts" activeClassName="user-center-navigation-active">
+              <span  className="fa-mail-reply fa-fw" />
               <div className="center-nav-item">我的回复</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/myfavorites" activeClassName="user-center-navigation-active" className="fa-star">
+            <NavLink to="/usercenter/myfavorites" activeClassName="user-center-navigation-active" >
+              <div className="fa-star fa-fw"/>
               <div className="center-nav-item">我的收藏</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/mycustomboards" activeClassName="user-center-navigation-active" className="fa-rss">
+            <NavLink to="/usercenter/mycustomboards" activeClassName="user-center-navigation-active" >
+              <span className="fa-rss fa-fw"/>
               <div className="center-nav-item">关注版面</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/myfollowings" activeClassName="user-center-navigation-active" className="fa-heart">
+            <NavLink to="/usercenter/myfollowings" activeClassName="user-center-navigation-active" >
+              <div className="fa-heart fa-fw" />
               <div className="center-nav-item">关注用户</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/myfans" activeClassName="user-center-navigation-active" className="fa-users">
+            <NavLink to="/usercenter/myfans" activeClassName="user-center-navigation-active">
+              <div  className="fa-users fa-fw" />
               <div className="center-nav-item">我的粉丝</div>
             </NavLink>
           </li>
@@ -106,15 +114,16 @@ export default class extends React.Component<props, UserCenterNavigationState> {
             <NavLink
               to="/usercenter/transferwealth"
               activeClassName="user-center-navigation-active"
-              className="fa-credit-card"
             >
+              <div className="fa-credit-card fa-fw" />
               <div className="center-nav-item">转账系统</div>
             </NavLink>
           </li>
           <hr />
           <li>
-            <NavLink to="/usercenter/theme" activeClassName="user-center-navigation-active" className="fa-magic">
-              <div className="center-nav-item">切换皮肤</div>
+            <NavLink to="/usercenter/theme" activeClassName="user-center-navigation-active" >
+              <div className="fa-magic fa-fw" />
+              <div className="center-nav-item ">切换皮肤</div>
             </NavLink>
           </li>
         </ul>

--- a/CC98.Forum/CC98.Forum/Components/UserCenter/Navigation.tsx
+++ b/CC98.Forum/CC98.Forum/Components/UserCenter/Navigation.tsx
@@ -77,7 +77,7 @@ export default class extends React.Component<props, UserCenterNavigationState> {
           <hr />
           <li>
             <NavLink to="/usercenter/myposts" activeClassName="user-center-navigation-active">
-              <span  className="fa-mail-reply fa-fw" />
+              <div  className="fa-mail-reply fa-fw" />
               <div className="center-nav-item">我的回复</div>
             </NavLink>
           </li>
@@ -91,7 +91,7 @@ export default class extends React.Component<props, UserCenterNavigationState> {
           <hr />
           <li>
             <NavLink to="/usercenter/mycustomboards" activeClassName="user-center-navigation-active" >
-              <span className="fa-rss fa-fw"/>
+              <div className="fa-rss fa-fw"/>
               <div className="center-nav-item">关注版面</div>
             </NavLink>
           </li>


### PR DESCRIPTION
本PR修复了#69 
通过给图标加上`fa-fw`的class，并将其放置在`<div>`中，实现导航菜单的对齐，~成功拯救了强迫症~
对比：
修改前
<img width="356" alt="Screenshot 2021-10-16 132446" src="https://user-images.githubusercontent.com/11483783/137575445-48cc4bb3-de41-466d-970c-9c1995bd1e7a.png">
修改后
<img width="338" alt="Screenshot 2021-10-16 132546" src="https://user-images.githubusercontent.com/11483783/137575447-83028ca1-3bee-4ffc-a847-ac14a29983dc.png">
