### PR TITLE
fix: 修正外链图片判断逻辑，确保只允许以 cc98.org 结尾的域名

### DIFF
--- a/Ubb/ImageTagHandler.tsx
+++ b/Ubb/ImageTagHandler.tsx
@@ -23,7 +23,7 @@ export class ImageTagHandler extends Ubb.TextTagHandler {
     let { allowImage, allowExternalImage, allowToolbox } = context.options;
 
     //不允许外链图片
-    if (!allowExternalImage && !parse(imageUri).hostname.includes("cc98.org")) {
+    if (!allowExternalImage && !parse(imageUri).hostname.endsWith("cc98.org")) {
       allowImage = false;
     }
 


### PR DESCRIPTION
实测如下格式的外链图片可以绕过原判断方式：

```
https://cc98.org.example.com/test.png
```

故对外链判断逻辑做了改动，将
```js
!parse(imageUri).hostname.include("cc98.org")
```
改为
```js
!parse(imageUri).hostname.endsWith("cc98.org")
```

顺便问一下不支持使用外链图片的原因